### PR TITLE
Navigation enable possibility in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,62 @@
 [![run-tests](https://github.com/visualbuilder/email-templates/actions/workflows/run-tests.yml/badge.svg)](https://github.com/visualbuilder/email-templates/actions/workflows/run-tests.yml)
 
 ### Why businesses and applications should use Email Templates
+
 - **Time-saving**: Email templates eliminate the need to create emails from scratch, saving valuable time and effort.
-- **Customizability**: Quick editing capabilities enable employees to personalize the content of the templates while maintaining a professional appearance.
-- **Consistent branding**: Templates ensure that all emails adhere to the brand's guidelines, reinforcing brand recognition and professionalism.
-- **Professional appearance**: Well-designed templates provide a polished and consistent look, enhancing the business's credibility and reputation.
+- **Customizability**: Quick editing capabilities enable employees to personalize the content of the templates while
+  maintaining a professional appearance.
+- **Consistent branding**: Templates ensure that all emails adhere to the brand's guidelines, reinforcing brand
+  recognition and professionalism.
+- **Professional appearance**: Well-designed templates provide a polished and consistent look, enhancing the business's
+  credibility and reputation.
 - **Streamlined communication**: Prompt and efficient communication.
-- **Flexibility**: Templates can be adapted for various purposes, such as promotional emails, customer support responses, newsletters, and more.
-- **Easy updates**: Templates can be easily modified to reflect changes in offers, policies, or design elements, ensuring that communication remains current and aligned with business objectives.
-- **Standardization**: Templates enforce a standardized structure and format for emails, reducing errors and improving clarity in communication.
-- **Scalability**: Email templates facilitate consistent messaging even as the business grows, ensuring a cohesive customer experience across all interactions.
-- **Improved productivity**: With quick access to templates, employees can focus more on core tasks, increasing overall productivity within the business.
+- **Flexibility**: Templates can be adapted for various purposes, such as promotional emails, customer support
+  responses, newsletters, and more.
+- **Easy updates**: Templates can be easily modified to reflect changes in offers, policies, or design elements,
+  ensuring that communication remains current and aligned with business objectives.
+- **Standardization**: Templates enforce a standardized structure and format for emails, reducing errors and improving
+  clarity in communication.
+- **Scalability**: Email templates facilitate consistent messaging even as the business grows, ensuring a cohesive
+  customer experience across all interactions.
+- **Improved productivity**: With quick access to templates, employees can focus more on core tasks, increasing overall
+  productivity within the business.
 
 ### This package provides:-
+
 - Content management for email templates allowing authorised users to edit email template content in the admin.
-- Templates can include model attribute tokens or config values which will be replaced, eg ##user.name## or ##config.app.name##
+- Templates can include model attribute tokens or config values which will be replaced, eg ##user.name## or
+  ##config.app.name##
 - Templates can be saved with different locales for multi-lingual capability.
-- A generic method for quickly creating mail classes to speed up adding new templates and faster automation possiblities.
+- A generic method for quickly creating mail classes to speed up adding new templates and faster automation
+  possiblities.
 - Theme editor - Set your own colours and apply to specific templates.
 
-We use the standard Laravel mail sending capability, the package simply allows content editing and faster adding of new template Classes
+We use the standard Laravel mail sending capability, the package simply allows content editing and faster adding of new
+template Classes
 
 ![Email Preview](https://raw.githubusercontent.com/visualbuilder/email-templates/3.x/media/ThemeEditor.jpg)
 
 ## Installation
 
 Get the package via composer:
+
 ```bash
 composer require visualbuilder/email-templates
 ```
-Running the install command will copy the template views, migrations, seeders and config file to your app.  
+
+Running the install command will copy the template views, migrations, seeders and config file to your app.
 
 The --seed option will populate 7 default templates which you can then edit in the admin panel.
+
 ```bash
  php artisan filament-email-templates:install --seed
 ```
+
 Note: The seeder can also be edited directly if you wish to prepopulate with your own content.
 `database\Seeders\EmailTemplateSeeder.php`
 
 ### Adding the plugin to a panel
+
 Add this plugin to panel using plugins() method in app/Providers/Filament/AdminPanelProvider.php:
 
 ```php
@@ -58,16 +76,63 @@ public function panel(Panel $panel): Panel
         ]);
 }
 ```
+
 Menu Group and sort order can be set in the config
+
+### Enabling navigation
+
+In the config file ``config/filament-email-templates.php`` navigation can be disabled/enabled
+
+```php
+    /**
+     * Admin panel navigation options
+     */
+    'navigation' => [
+        'enabled' => true,
+        'templates' => [
+            'sort' => 10,
+            'label' => 'Email Templates',
+            'icon' => 'heroicon-o-envelope',
+            'group' => 'Content',
+            'cluster' => false,
+            'position' => SubNavigationPosition::Top
+        ],
+        'themes' => [
+            'sort' => 20,
+            'label' => 'Email Template Themes',
+            'icon' => 'heroicon-o-paint-brush',
+            'group' => 'Content',
+            'cluster' => false,
+            'position' => SubNavigationPosition::Top
+        ],
+    ],
+
+```
+
+Or you can use a closure to enable navigation only for specific users:
+
+```php
+// AdminPanelProvider.php
+    ->plugins([
+// ...
+        EmailTemplatesPlugin::make()
+                ->enableNavigation(
+                    fn () => auth()->user()->can('view_email_templates') || auth()->user()->can('view_any_email_templates)'),
+               ),
+    ])
+```
 
 ## Usage
 
 ### HTML Editor
+
 Edit email content in the admin and use tokens to inject model or config content.
 ![Email Preview](https://raw.githubusercontent.com/visualbuilder/email-templates/3.x/media/EmailEditor.png)
 
 ### Tokens
-Token format is ##model.attribute##.  When calling the email pass any referenced models to replace the tokens automatically.
+
+Token format is ##model.attribute##. When calling the email pass any referenced models to replace the tokens
+automatically.
 
 You can also include config values in the format ##config.file.key## eg ##config.app.name##.
 
@@ -83,26 +148,29 @@ You can also include config values in the format ##config.file.key## eg ##config
         'app.url',
         'email-templates.customer-services'
 ```
+
 ### Implementing out of the box templates
 
-Emails may be sent directly, via a notification or an event listener.  
+Emails may be sent directly, via a notification or an event listener.
 
 The following email templates are included to get you started and show different methods of sending.
 
- - **User Registered**  - Welcome them to the platform
- - **User Verify Email** - Check they are human
- - **User Verified Email** - Yes they are
- - **User Request Password Reset** - Let them change the password
- - **User Password Reset Success** - Yay, you changed your password
- - **User Locked Out** - Oops - What to do now?
- - **User Login** - Success
+- **User Registered**  - Welcome them to the platform
+- **User Verify Email** - Check they are human
+- **User Verified Email** - Yes they are
+- **User Request Password Reset** - Let them change the password
+- **User Password Reset Success** - Yay, you changed your password
+- **User Locked Out** - Oops - What to do now?
+- **User Login** - Success
 
 Not all systems will require a login notification, but it's good practice for security so included here.
 
 #### New User Registered Email
+
 A new **Registered** event is triggered when creating a new user.
 
-We want to welcome new users with a friendly email so we've included a listener for the Illuminate\Auth\Events\Registered Event
+We want to welcome new users with a friendly email so we've included a listener for the
+Illuminate\Auth\Events\Registered Event
 which will send the email if enabled in the config:-
 
 ```php
@@ -117,7 +185,9 @@ which will send the email if enabled in the config:-
 ```
 
 #### User Verify Email
-This notification is built in to Laravel so we have overidden the default toMail function to use our custom email template.
+
+This notification is built in to Laravel so we have overidden the default toMail function to use our custom email
+template.
 
 For reference this is done in the `EmailTemplatesAuthServiceProvider`.
 
@@ -129,11 +199,12 @@ To Enable email verification ensure the User model implements the Laravel MustVe
 class User extends Authenticatable implements MustVerifyEmail
 ```
 
-and include the **verified** middleware in your routes. 
-
+and include the **verified** middleware in your routes.
 
 #### User Request Password Reset
-Another Laravel built in notification, but to enable the custom email just add this function to your authenticatable user model.
+
+Another Laravel built in notification, but to enable the custom email just add this function to your authenticatable
+user model.
 
 ```php
 
@@ -152,11 +223,13 @@ use Visualbuilder\EmailTemplates\Notifications\UserResetPasswordRequestNotificat
     }
 ```
 
-
 ### Customising the email template
-Some theme colour options have been provided.  Email templates will use the default theme unless you specify otherwise on the email template.
+
+Some theme colour options have been provided. Email templates will use the default theme unless you specify otherwise on
+the email template.
 
 In the config file ``config/filament-email-templates.php`` logo, contacts, links and admin preferences can be set
+
 ```php
 
     //Default Logo
@@ -180,23 +253,31 @@ In the config file ``config/filament-email-templates.php`` logo, contacts, links
     ],
 
 ```
+
 If you wish to directly edit the template blade files, see the primary template here:
+
 - **Path**: `resources/views/vendor/vb-email-templates/email/default.php`
 
 New templates in this directory will be automatically visible in the email template editor dropdown for selection.
 
 #### Useful Tip
-Not all email clients (e.g., Outlook) render CSS from a stylesheet effectively. To ensure maximum compatibility, it's best to **put styles inline**. For checking how your email looks across different clients, [Litmus Email Previews](https://www.litmus.com/landing-page/email-previews) is highly recommended.
+
+Not all email clients (e.g., Outlook) render CSS from a stylesheet effectively. To ensure maximum compatibility, it's
+best to **put styles inline**. For checking how your email looks across different
+clients, [Litmus Email Previews](https://www.litmus.com/landing-page/email-previews) is highly recommended.
 
 ### Translations
+
 Each email template is identified by a key and a language:
 
 - **Key**: `user-password-reset`
 - **Language**: `en_gb`
 
-This allows the relevant template to be selected based on the users locale - You will need to save the users preferred language to implement this.
+This allows the relevant template to be selected based on the users locale - You will need to save the users preferred
+language to implement this.
 
-Please note laravel default locale is just "en" we prefer to separate British and American English so typically use en_GB and en_US instead but you can set this value as you wish.
+Please note laravel default locale is just "en" we prefer to separate British and American English so typically use
+en_GB and en_US instead but you can set this value as you wish.
 
 Languages that should be shown on the language picker can be set in the config
 
@@ -219,10 +300,10 @@ Languages that should be shown on the language picker can be set in the config
 Flag icons are loaded from CDN: https://cdn.jsdelivr.net/gh/lipis/flag-icons@6.6.6/css/flag-icons.min.css
 see https://www.npmjs.com/package/flag-icons
 
-
 ### Creating new Mail Classes
 
-We've currently opted to keep using a separate Mailable Class for each email type.  This means when you create a new template in the admin, it will require a new php Class.
+We've currently opted to keep using a separate Mailable Class for each email type. This means when you create a new
+template in the admin, it will require a new php Class.
 The package provides an action to build the class if the file does not exist in app\Mail\VisualBuilder\EmailTemplates.
 
 ![Build Class](https://raw.githubusercontent.com/visualbuilder/email-templates/3.x/media/BuildClass.png)
@@ -257,6 +338,7 @@ class MyFunkyNewEmail extends Mailable
 ```
 
 ### Including other models in the email for token replacement
+
 Just pass through the models you need and assign them in the constructor.
 
 ```php
@@ -277,12 +359,11 @@ class MyFunkyNewEmail extends Mailable
 
 In this example you can then use **##booking.date##** or whatever attributes are available in the booking model.
 
-If you need to derive some attribute you can add Accessors to your model.  
+If you need to derive some attribute you can add Accessors to your model.
 
 Both of these function will allow you to use:-
 
 **##user.full_name##** in the email template:-
-
 
 ```php
 public function getFullNameAttribute()
@@ -290,7 +371,9 @@ public function getFullNameAttribute()
   return $this->firstname.' '.$this->lastname;
 }
 ```
+
 OR
+
 ```php
 protected function fullName(): Attribute
 {
@@ -300,8 +383,8 @@ protected function fullName(): Attribute
 }
 ```
 
-
 ### Adding Attachments
+
 In here you can see how to pass an attachment:-
 
 The attachment should be passed to the Mail Class and set as a public property.
@@ -395,7 +478,7 @@ You should also include the filetype.
     }
 ```
 
-To maximise compatibility we've kept with the L9 mailable methods -> which still work on L10. 
+To maximise compatibility we've kept with the L9 mailable methods -> which still work on L10.
 
 ### Testing
 
@@ -417,7 +500,7 @@ If you discover any security related issues, please email support@ekouk.com inst
 
 ## Credits
 
--   [Visual Builder](https://github.com/visualbuilder)
+- [Visual Builder](https://github.com/visualbuilder)
 
 ## License
 

--- a/config/filament-email-templates.php
+++ b/config/filament-email-templates.php
@@ -1,5 +1,8 @@
 <?php
 
+use Filament\Pages\SubNavigationPosition;
+use Visualbuilder\EmailTemplates\DefaultTokenHelper;
+
 return [
     /**
      * If you wish to customise the table name change this before migration
@@ -31,7 +34,7 @@ return [
      *  }
      */
 
-    'tokenHelperClass' => \Visualbuilder\EmailTemplates\DefaultTokenHelper::class,
+    'tokenHelperClass' => DefaultTokenHelper::class,
 
 
     /**
@@ -47,13 +50,14 @@ return [
      * Admin panel navigation options
      */
     'navigation' => [
+        'enabled' => true,
         'templates' => [
             'sort' => 10,
             'label' => 'Email Templates',
             'icon' => 'heroicon-o-envelope',
             'group' => 'Content',
             'cluster' => false,
-            'position' => \Filament\Pages\SubNavigationPosition::Top
+            'position' => SubNavigationPosition::Top
         ],
         'themes' => [
             'sort' => 20,
@@ -61,7 +65,7 @@ return [
             'icon' => 'heroicon-o-paint-brush',
             'group' => 'Content',
             'cluster' => false,
-            'position' => \Filament\Pages\SubNavigationPosition::Top
+            'position' => SubNavigationPosition::Top
         ],
     ],
 
@@ -72,13 +76,13 @@ return [
     'template_view_path' => 'vb-email-templates::email',
 
     'template_keys' => [
-            'user-welcome'=>'User Welcome Email',
-            'user-request-reset'=>'User Request Password Reset',
-            'user-password-reset-success'=>'User Password Reset',
-            'user-locked-out'=>'User Account Locked Out',
-            'user-verify-email'=>'User Verify Email',
-            'user-verified'=>'User Verified',
-            'user-login'=>'User Logged In',
+        'user-welcome' => 'User Welcome Email',
+        'user-request-reset' => 'User Request Password Reset',
+        'user-password-reset-success' => 'User Password Reset',
+        'user-locked-out' => 'User Account Locked Out',
+        'user-verify-email' => 'User Verify Email',
+        'user-verified' => 'User Verified',
+        'user-login' => 'User Logged In',
     ],
 
     //Default Logo
@@ -95,13 +99,18 @@ return [
     'content_width' => '600',
 
     //Contact details included in default email templates
-    'customer-services' => ['email' => 'support@yourcompany.com',
-        'phone' => '+441273 455702'],
+    'customer-services' => [
+        'email' => 'support@yourcompany.com',
+        'phone' => '+441273 455702'
+    ],
 
     //Footer Links
     'links' => [
         ['name' => 'Website', 'url' => 'https://yourwebsite.com', 'title' => 'Goto website'],
-        ['name' => 'Privacy Policy', 'url' => 'https://yourwebsite.com/privacy-policy', 'title' => 'View Privacy Policy'],
+        [
+            'name' => 'Privacy Policy', 'url' => 'https://yourwebsite.com/privacy-policy',
+            'title' => 'View Privacy Policy'
+        ],
     ],
 
     //Options for alternative languages

--- a/src/EmailTemplatesPlugin.php
+++ b/src/EmailTemplatesPlugin.php
@@ -2,14 +2,20 @@
 
 namespace Visualbuilder\EmailTemplates;
 
+use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Visualbuilder\EmailTemplates\Resources\EmailTemplateResource;
 use Visualbuilder\EmailTemplates\Resources\EmailTemplateThemeResource;
 
 class EmailTemplatesPlugin implements Plugin
 {
+    use EvaluatesClosures;
+
     public string $navigationGroup;
+
+    protected bool|Closure $navigation = true;
 
     public static function make(): static
     {
@@ -26,6 +32,19 @@ class EmailTemplatesPlugin implements Plugin
         return 'filament-email-templates';
     }
 
+    public function enableNavigation(bool|Closure $callback = true): static
+    {
+        $this->navigation = $callback;
+
+        return $this;
+    }
+
+    public function shouldRegisterNavigation(): bool
+    {
+        return $this->evaluate($this->navigation) === true ?? config('filament-email-templates.navigation.enabled',
+            true);
+    }
+
     public function navigationGroup($navigationGroup): static
     {
         $this->navigationGroup = $navigationGroup;
@@ -40,8 +59,8 @@ class EmailTemplatesPlugin implements Plugin
     public function register(Panel $panel): void
     {
         $panel->resources([
-                EmailTemplateResource::class,
-                EmailTemplateThemeResource::class,
+            EmailTemplateResource::class,
+            EmailTemplateThemeResource::class,
         ]);
 
     }

--- a/src/Resources/EmailTemplateThemeResource.php
+++ b/src/Resources/EmailTemplateThemeResource.php
@@ -19,6 +19,12 @@ class EmailTemplateThemeResource extends Resource
 {
     protected static ?string $model = EmailTemplateTheme::class;
 
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return EmailTemplatesPlugin::get()->shouldRegisterNavigation();
+    }
+
     public static function getNavigationIcon(): ?string
     {
         return config('filament-email-templates.navigation.themes.icon');
@@ -57,77 +63,78 @@ class EmailTemplateThemeResource extends Resource
     public static function form(Form $form): Form
     {
         return $form
-                ->schema([
-                        Forms\Components\Group::make()
-                                ->schema([
-                                        Forms\Components\Section::make(__('vb-email-templates::email-templates.theme-form-fields-labels.template-preview'))
-                                                ->schema([
-                                                        Forms\Components\ViewField::make('preview')->view('vb-email-templates::email.default_preview', ['data' => self::getPreviewData()]),
-                                                ])
-                                                ->columnSpan(['lg' => 2]),
-                                ])
-                                ->columnSpan(['lg' => 2]),
+            ->schema([
+                Forms\Components\Group::make()
+                    ->schema([
+                        Forms\Components\Section::make(__('vb-email-templates::email-templates.theme-form-fields-labels.template-preview'))
+                            ->schema([
+                                Forms\Components\ViewField::make('preview')->view('vb-email-templates::email.default_preview',
+                                    ['data' => self::getPreviewData()]),
+                            ])
+                            ->columnSpan(['lg' => 2]),
+                    ])
+                    ->columnSpan(['lg' => 2]),
 
-                        Forms\Components\Group::make()
-                                ->schema([
-                                        Forms\Components\Section::make()
-                                                ->schema([
-                                                        Forms\Components\TextInput::make('name')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.theme-name'))
-                                                                ->columnSpan(3),
+                Forms\Components\Group::make()
+                    ->schema([
+                        Forms\Components\Section::make()
+                            ->schema([
+                                Forms\Components\TextInput::make('name')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.theme-name'))
+                                    ->columnSpan(3),
 
-                                                        Forms\Components\Toggle::make('is_default')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.is-default'))
-                                                                ->inline(false)
-                                                                ->onColor('success')
-                                                                ->offColor('danger'),
-                                                ]),
+                                Forms\Components\Toggle::make('is_default')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.is-default'))
+                                    ->inline(false)
+                                    ->onColor('success')
+                                    ->offColor('danger'),
+                            ]),
 
-                                        Forms\Components\Section::make(__('vb-email-templates::email-templates.theme-form-fields-labels.set-colors'))
-                                                ->schema([
-                                                        Forms\Components\ColorPicker::make('colours.header_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.header-bg'))
-                                                                ->live(),
+                        Forms\Components\Section::make(__('vb-email-templates::email-templates.theme-form-fields-labels.set-colors'))
+                            ->schema([
+                                Forms\Components\ColorPicker::make('colours.header_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.header-bg'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.body_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.body-bg'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.body_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.body-bg'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.content_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.content-bg'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.content_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.content-bg'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.footer_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.footer-bg')),
+                                Forms\Components\ColorPicker::make('colours.footer_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.footer-bg')),
 
-                                                        Forms\Components\ColorPicker::make('colours.callout_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.callout-bg'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.callout_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.callout-bg'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.button_bg_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.button-bg'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.button_bg_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.button-bg'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.body_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.body-color'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.body_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.body-color'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.callout_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.callout-color'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.callout_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.callout-color'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.button_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.button-color'))
-                                                                ->live(),
+                                Forms\Components\ColorPicker::make('colours.button_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.button-color'))
+                                    ->live(),
 
-                                                        Forms\Components\ColorPicker::make('colours.anchor_color')
-                                                                ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.anchor-color'))
-                                                                ->live(),
-                                                ]),
+                                Forms\Components\ColorPicker::make('colours.anchor_color')
+                                    ->label(__('vb-email-templates::email-templates.theme-form-fields-labels.anchor-color'))
+                                    ->live(),
+                            ]),
 
-                                ])
-                                ->columnSpan(['lg' => 1]),
-                ])->columns(3);
+                    ])
+                    ->columnSpan(['lg' => 1]),
+            ])->columns(3);
     }
 
     public static function getPreviewData()
@@ -140,43 +147,43 @@ class EmailTemplateThemeResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-                ->columns([
-                        Tables\Columns\TextColumn::make('id')->sortable()->searchable(),
-                        Tables\Columns\TextColumn::make('name')->sortable()->searchable(),
-                        Tables\Columns\IconColumn::make('is_default')->boolean(),
-                ])
-                ->filters([
-                    //
-                ])
-                ->actions([
-                        Tables\Actions\EditAction::make(),
-                ])
-                ->bulkActions([
-                        Tables\Actions\BulkActionGroup::make([
-                                Tables\Actions\DeleteBulkAction::make(),
-                        ]),
-                ])
-                ->emptyStateActions([
-                        Tables\Actions\CreateAction::make(),
-                ]);
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable()->searchable(),
+                Tables\Columns\TextColumn::make('name')->sortable()->searchable(),
+                Tables\Columns\IconColumn::make('is_default')->boolean(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->emptyStateActions([
+                Tables\Actions\CreateAction::make(),
+            ]);
     }
 
     public static function getPages(): array
     {
         return [
-                'index'  => Pages\ListEmailTemplateThemes::route('/'),
-                'create' => Pages\CreateEmailTemplateTheme::route('/create'),
-                'edit'   => Pages\EditEmailTemplateTheme::route('/{record}/edit'),
+            'index' => Pages\ListEmailTemplateThemes::route('/'),
+            'create' => Pages\CreateEmailTemplateTheme::route('/create'),
+            'edit' => Pages\EditEmailTemplateTheme::route('/{record}/edit'),
         ];
     }
 
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
-                ->withoutGlobalScopes(
-                        [
-                                SoftDeletingScope::class,
-                        ]
-                );
+            ->withoutGlobalScopes(
+                [
+                    SoftDeletingScope::class,
+                ]
+            );
     }
 }


### PR DESCRIPTION
In my projekt we have admins and super-admins. The admins should not have the permission to change the mail templates. So I adjusted the posibility of view navigation items due to the config file. Additionaly I implemented the possibility to change the visibility of the navigation items depending on the closure that is given in the plugin registration.

Exaple:
```php
// AdminPanelProvider.php
    ->plugins([
// ...
        EmailTemplatesPlugin::make()
                ->enableNavigation(
                    fn () => auth()->user()->can('view_email_templates') || auth()->user()->can('view_any_email_templates)'),
               ),
    ])
```