### PR TITLE
Fix duplicate Verify email sent out

### DIFF
--- a/src/EmailTemplatesEventServiceProvider.php
+++ b/src/EmailTemplatesEventServiceProvider.php
@@ -50,4 +50,6 @@ class EmailTemplatesEventServiceProvider extends ServiceProvider
 
         //
     }
+
+    protected function configureEmailVerification() {}
 }


### PR DESCRIPTION
In laravel 11, the `configureEmailVerifiaction` registers the `SendEmailVerificationNotification`, even if the Registered has a listener already. It makes the Verify email sent out 2 times (or more, if you are using modules with the default EventServiceProvider)

This happens only with the MustVerifyEmail flow

```
protected function configureEmailVerification()
    {
        if (! isset($this->listen[Registered::class]) ||
            ! in_array(SendEmailVerificationNotification::class, Arr::wrap($this->listen[Registered::class]))) {
            Event::listen(Registered::class, SendEmailVerificationNotification::class);
        }
    }
```