### PR TITLE
Fix logo_url removal when saving templates

### DIFF
--- a/src/Resources/EmailTemplateResource.php
+++ b/src/Resources/EmailTemplateResource.php
@@ -306,7 +306,7 @@ class EmailTemplateResource extends Resource
         if ($data['logo_type'] == "paste_url" && $data['logo_url']) {
             $data['logo'] = $data['logo_url'];
         }
-        unset($data['logo_type']);
+        unset($data['logo_type'], $data['logo_url']);
         return $data;
     }
 }


### PR DESCRIPTION
## Summary
- remove `logo_url` from the data array before saving

## Testing
- `./vendor/bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687fc075426c8333867488e9bc44c5f5