### PR TITLE
Fix missing Log facade import

### DIFF
--- a/src/Helpers/CreateMailableHelper.php
+++ b/src/Helpers/CreateMailableHelper.php
@@ -4,6 +4,7 @@ namespace Visualbuilder\EmailTemplates\Helpers;
 
 use Exception;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Visualbuilder\EmailTemplates\Contracts\CreateMailableInterface;
 


### PR DESCRIPTION
## Summary
- import the Log facade for mailable generation helper

## Testing
- `composer test`
- `composer format` *(fails: `vendor/bin/pint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687fc03d43648333a2fdfd7098b33fe1