### PR TITLE
Fix preview field hydration

### DIFF
--- a/src/Resources/EmailTemplateThemeResource.php
+++ b/src/Resources/EmailTemplateThemeResource.php
@@ -69,7 +69,8 @@ class EmailTemplateThemeResource extends Resource
                         Forms\Components\Section::make(__('vb-email-templates::email-templates.theme-form-fields-labels.template-preview'))
                             ->schema([
                                 Forms\Components\ViewField::make('preview')->view('vb-email-templates::email.default_preview',
-                                    ['data' => self::getPreviewData()]),
+                                    ['data' => self::getPreviewData()])
+                                    ->dehydrated(false),
                             ])
                             ->columnSpan(['lg' => 2]),
                     ])


### PR DESCRIPTION
## Summary
- stop `preview` field from being sent when saving email template themes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687fc01c4ee08333ae697568338efe85