### PR TITLE
Fix README snippet for optional preheader

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,8 +550,8 @@ You should also include the filetype.
 
         $data = [
             'content'       => TokenHelper::replace($template->content, $this),
-            'preHeaderText' => TokenHelper::replace($template->preheader, $this),
-            'title'         => TokenHelper::replace($template->title, $this)
+            'preHeaderText' => TokenHelper::replace($template->preheader ?? '', $this),
+            'title'         => TokenHelper::replace($template->title ?? '', $this)
         ];
 
         return $this->from($template->from['email'],$template->from['name'])

--- a/src/Traits/BuildGenericEmail.php
+++ b/src/Traits/BuildGenericEmail.php
@@ -37,9 +37,9 @@ trait BuildGenericEmail
         }
 
         $data = [
-                'content'       => TokenHelper::replace($this->emailTemplate->content??"", $this),
-                'preHeaderText' => TokenHelper::replace($this->emailTemplate->preheader??"", $this),
-                'title'         => TokenHelper::replace($this->emailTemplate->title??"", $this),
+                'content'       => TokenHelper::replace($this->emailTemplate->content ?? '', $this),
+                'preHeaderText' => TokenHelper::replace($this->emailTemplate->preheader ?? '', $this),
+                'title'         => TokenHelper::replace($this->emailTemplate->title ?? '', $this),
                 'theme'         => $this->emailTemplate->theme->colours,
                 'logo'          => $this->emailTemplate->logo,
         ];


### PR DESCRIPTION
## Summary
- fix example mailable snippet to handle optional preheader/title
- ensure BuildGenericEmail trait uses same defaults

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_687fbf0e3cdc8333834503982664db49