### PR TITLE
Fix default preview blade for standalone use

### DIFF
--- a/resources/views/email/default_preview.blade.php
+++ b/resources/views/email/default_preview.blade.php
@@ -1,5 +1,11 @@
 
-<?php $data['theme'] = $this->data['colours'] ?>
+@php
+    if (isset($data['colours'])) {
+        $data['theme'] = $data['colours'];
+    } elseif (isset($this) && isset($this->data['colours'])) {
+        $data['theme'] = $this->data['colours'];
+    }
+@endphp
 
 <div style="background-color: {{$data['theme']["body_bg_color"]}};">
 


### PR DESCRIPTION
## Summary
- avoid using `$this` in `default_preview` view
- handle colors from passed data or Livewire context

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687fca475938833395a4bbc493d040ec