### PR TITLE
Fix template model mass assignment

### DIFF
--- a/src/Models/EmailTemplate.php
+++ b/src/Models/EmailTemplate.php
@@ -83,6 +83,23 @@ class EmailTemplate extends Model
     {
         parent::__construct($attributes);
         $this->setTableFromConfig();
+        // Include the theme foreign key as a fillable attribute
+        $this->fillable[] = config('filament-email-templates.theme_table_name') . '_id';
+    }
+
+    /**
+     * Remove temporary logo fields before mass assignment.
+     */
+    public function fill(array $attributes)
+    {
+        if (isset($attributes['logo_url'])) {
+            if (($attributes['logo_type'] ?? null) === 'paste_url' && $attributes['logo_url']) {
+                $attributes['logo'] = $attributes['logo_url'];
+            }
+            unset($attributes['logo_url'], $attributes['logo_type']);
+        }
+
+        return parent::fill($attributes);
     }
 
     protected static function boot()


### PR DESCRIPTION
## Summary
- allow theme foreign key in the template model
- filter `logo_url` field during mass assignment so untracked column doesn't cause errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687fc95916f883339219baeae3fac1bd