### PR TITLE
Fix lockout notification config

### DIFF
--- a/src/Notifications/UserLockoutNotification.php
+++ b/src/Notifications/UserLockoutNotification.php
@@ -30,7 +30,9 @@ class UserLockoutNotification extends Notification
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return config('filament-email-templates.send_emails.locked_out')
+            ? ['mail']
+            : [];
     }
 
     /**
@@ -41,9 +43,7 @@ class UserLockoutNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        if(config('filament-email-templates.send_emails.user_lockout')) {
-            return app(UserLockedOutEmail::class, ['user' => $notifiable]);
-        }
+        return app(UserLockedOutEmail::class, ['user' => $notifiable]);
     }
 
     /**

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -6,6 +6,7 @@ use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 use Orchestra\Testbench\Factories\UserFactory;
 
 /**
@@ -15,7 +16,7 @@ use Orchestra\Testbench\Factories\UserFactory;
  */
 class User extends Authenticatable implements FilamentUser
 {
-    use HasFactory;
+    use HasFactory, Notifiable;
 
     protected $guarded = [];
 

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Notification;
+use Visualbuilder\EmailTemplates\Notifications\UserLockoutNotification;
+use Visualbuilder\EmailTemplates\Tests\Models\User;
+
+it('does not send locked out notification when disabled', function () {
+    Notification::fake();
+
+    config()->set('filament-email-templates.send_emails.locked_out', false);
+
+    $user = User::create([
+        'name' => 'Test User',
+        'email' => 'user@example.com',
+        'password' => 'password',
+    ]);
+
+    $user->notify(new UserLockoutNotification());
+
+    Notification::assertNothingSent();
+});
+


### PR DESCRIPTION
## Summary
- handle `locked_out` config in `UserLockoutNotification`
- always return `UserLockedOutEmail` from `toMail`
- make test user notifiable
- test that triggering notification while disabled doesn't error

## Testing
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_687fcfb3ced08333afa2a66ff0454372