### PR TITLE
Add tests for FormHelper::getFiles

### DIFF
--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use ReflectionMethod;
+use Visualbuilder\EmailTemplates\Helpers\FormHelper;
+
+it('recursively collects blade views and ignores underscore directories', function () {
+    $baseDir = base_path('tests/tmp/views');
+
+    File::deleteDirectory($baseDir);
+
+    // create nested directories
+    File::ensureDirectoryExists($baseDir.'/sub/nested', 0755, true);
+    File::ensureDirectoryExists($baseDir.'/_ignored');
+    File::ensureDirectoryExists($baseDir.'/sub/_private');
+
+    // create files
+    File::put($baseDir.'/welcome.blade.php', '');
+    File::put($baseDir.'/_hidden.blade.php', '');
+    File::put($baseDir.'/sub/alpha.blade.php', '');
+    File::put($baseDir.'/sub/nested/detail.blade.php', '');
+    File::put($baseDir.'/_ignored/hidden.blade.php', '');
+    File::put($baseDir.'/sub/_private/secret.blade.php', '');
+
+    // access private method
+    $method = new ReflectionMethod(FormHelper::class, 'getFiles');
+    $method->setAccessible(true);
+    $files = $method->invoke(null, $baseDir, $baseDir);
+
+    expect($files)->toEqualCanonicalizing([
+        'welcome',
+        'sub.alpha',
+        'sub.nested.detail',
+    ]);
+
+    File::deleteDirectory($baseDir);
+});
+


### PR DESCRIPTION
## Summary
- cover private `getFiles` helper via reflection
- ensure underscore-prefixed directories are skipped when generating view list

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687fe074546c833385d2beed3aeb202e