### PR TITLE
Add listener notification tests

### DIFF
--- a/src/Notifications/UserLockoutNotification.php
+++ b/src/Notifications/UserLockoutNotification.php
@@ -41,7 +41,7 @@ class UserLockoutNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        if(config('filament-email-templates.send_emails.user_lockout')) {
+        if(config('filament-email-templates.send_emails.locked_out')) {
             return app(UserLockedOutEmail::class, ['user' => $notifiable]);
         }
     }

--- a/tests/ListenersTest.php
+++ b/tests/ListenersTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Support\Facades\Notification;
+use Visualbuilder\EmailTemplates\Tests\Models\User;
+use Visualbuilder\EmailTemplates\Notifications\UserLoginNotification;
+use Visualbuilder\EmailTemplates\Notifications\UserRegisteredNotification;
+use Visualbuilder\EmailTemplates\Notifications\UserPasswordResetNotification;
+use Visualbuilder\EmailTemplates\Notifications\UserLockoutNotification;
+use Visualbuilder\EmailTemplates\Notifications\UserVerifiedNotification;
+use Visualbuilder\EmailTemplates\Listeners\UserLockoutListener;
+
+it('sends login notification based on config flag', function () {
+    $user = User::factory()->create();
+
+    // when enabled
+    Notification::fake();
+    config(['filament-email-templates.send_emails.login' => true]);
+    event(new Login('web', $user, false));
+    Notification::assertSentTo($user, UserLoginNotification::class);
+
+    // when disabled
+    Notification::fake();
+    config(['filament-email-templates.send_emails.login' => false]);
+    event(new Login('web', $user, false));
+    Notification::assertNothingSent();
+});
+
+it('sends registered notification based on config flag', function () {
+    $user = User::factory()->create();
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.new_user_registered' => true]);
+    event(new Registered($user));
+    Notification::assertSentTo($user, UserRegisteredNotification::class);
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.new_user_registered' => false]);
+    event(new Registered($user));
+    Notification::assertNothingSent();
+});
+
+it('sends password reset notification based on config flag', function () {
+    $user = User::factory()->create();
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.password_reset_success' => true]);
+    event(new PasswordReset($user));
+    Notification::assertSentTo($user, UserPasswordResetNotification::class);
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.password_reset_success' => false]);
+    event(new PasswordReset($user));
+    Notification::assertNothingSent();
+});
+
+it('sends lockout notification based on config flag', function () {
+    $user = User::factory()->create();
+
+    Notification::fake();
+    \Illuminate\Support\Facades\Event::listen(Login::class, UserLockoutListener::class);
+    config(['filament-email-templates.send_emails.locked_out' => true]);
+    event(new Login('web', $user, false));
+    Notification::assertSentTo($user, UserLockoutNotification::class);
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.locked_out' => false]);
+    event(new Login('web', $user, false));
+    Notification::assertNotSentTo($user, UserLockoutNotification::class);
+});
+
+it('sends verified notification based on config flag', function () {
+    $user = User::factory()->create();
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.user_verified' => true]);
+    event(new Verified($user));
+    Notification::assertSentTo($user, UserVerifiedNotification::class);
+
+    Notification::fake();
+    config(['filament-email-templates.send_emails.user_verified' => false]);
+    event(new Verified($user));
+    Notification::assertNothingSent();
+});

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -5,6 +5,7 @@ namespace Visualbuilder\EmailTemplates\Tests\Models;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Notifications\Notifiable as LaravelNotifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Orchestra\Testbench\Factories\UserFactory;
 
@@ -15,7 +16,7 @@ use Orchestra\Testbench\Factories\UserFactory;
  */
 class User extends Authenticatable implements FilamentUser
 {
-    use HasFactory;
+    use HasFactory, LaravelNotifiable;
 
     protected $guarded = [];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,7 @@ class TestCase extends Orchestra
         );
 
         Config::set('filament-email-templates.recipients', ['\\Visualbuilder\\EmailTemplates\\Tests\\Models\\User']);
+        Config::set('auth.providers.users.model', User::class);
     }
 
     protected function getPackageProviders($app): array


### PR DESCRIPTION
## Summary
- add test for event listeners dispatching notifications
- enable notifications in user model and test case setup
- correct config check for lockout notification
- fix Notifiable trait alias in test user

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687fe06a65b08333924a15876f57e0e2