### PR TITLE
Upgrade to Laravel 11 and Filament 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Menu Group and sort order can be set in the config
 In the config file ``config/filament-email-templates.php`` navigation can be disabled/enabled
 
 ```php
+use Filament\Pages\Enums\SubNavigationPosition;
+
     /**
      * Admin panel navigation options
      */

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "filament/filament": "^4.0",
+        "illuminate/contracts": "^11.0",
         "visualbuilder/filament-tinyeditor": "dev-main",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "blade-ui-kit/blade-heroicons": "^2.1",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.9.1 || ^3.0",
         "pestphp/pest-plugin-laravel": "^2.2 || ^3.0",
         "pestphp/pest-plugin-livewire": "^2.1 | ^3.0",

--- a/config/filament-email-templates.php
+++ b/config/filament-email-templates.php
@@ -1,6 +1,6 @@
 <?php
 
-use Filament\Pages\SubNavigationPosition;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Visualbuilder\EmailTemplates\DefaultTokenHelper;
 
 return [

--- a/src/Resources/EmailTemplateResource.php
+++ b/src/Resources/EmailTemplateResource.php
@@ -12,7 +12,7 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
-use Filament\Pages\SubNavigationPosition;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;

--- a/src/Resources/EmailTemplateThemeResource.php
+++ b/src/Resources/EmailTemplateThemeResource.php
@@ -4,7 +4,7 @@ namespace Visualbuilder\EmailTemplates\Resources;
 
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Pages\SubNavigationPosition;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;


### PR DESCRIPTION
## Summary
- bump to Filament v4 and Laravel 11 component contracts
- update references to `Filament\Pages\Enums\SubNavigationPosition`
- document new namespace usage

## Testing
- `composer test` *(fails: Class "Filament\Pages\Enums\SubNavigationPosition" not found)*
- `vendor/bin/pest tests/NotificationTest.php --stop-on-failure` *(fails: Class "Filament\Pages\Enums\SubNavigationPosition" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45e00cca083339d30aaec53cb406d