### PR TITLE
chore: allow laravel 13 (testbench ^11) and cover it in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.3,8.4]
-                laravel: [11.*,12.*]
+                laravel: [11.*,12.*,13.*]
                 stability: [ prefer-stable ]
                 filament: [5.*]
                 dependency-version: [ prefer-stable]
@@ -20,6 +20,9 @@ jobs:
                         filament: 5.*
                     -   laravel: 12.*
                         testbench: 10.*
+                        filament: 5.*
+                    -   laravel: 13.*
+                        testbench: 11.*
                         filament: 5.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "blade-ui-kit/blade-heroicons": "^2.1",
-        "orchestra/testbench": "^9.0 || ^10.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "pestphp/pest": "^3.0 || ^4.0",
         "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
         "pestphp/pest-plugin-livewire": "^4.0",


### PR DESCRIPTION
Part of the Laravel 13 readiness sweep across visualbuilder packages (neurobox NB-2860 groundwork).

Constraint widening only — no behaviour changes. Suite verified locally on laravel/framework **v13.19.0**: 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)